### PR TITLE
feat: add Docker Compose for full stack deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,48 @@ Predict NFL game outcomes, find edges against the sportsbook lines, and size bet
 
 ## Quick Start
 
+### Option 1: Docker (Recommended)
+
+Run the entire stack with Docker Compose:
+
+```bash
+# Clone all repos in the same parent directory
+git clone https://github.com/Kame4201/beat-books-data.git
+git clone https://github.com/Kame4201/beat-books-api.git
+git clone https://github.com/Kame4201/beat-books-infra.git
+
+# Set up environment
+cd beat-books-infra/docker
+cp .env.example .env
+# Edit .env and set DB_PASSWORD
+
+# Start the stack (production mode)
+cd ..
+./scripts/docker-up.sh
+
+# Or for development with hot reload
+./scripts/docker-up.sh dev
+
+# Or for testing
+./scripts/docker-up.sh test
+
+# Windows PowerShell
+.\scripts\docker-up.ps1 dev
+```
+
+**Services will be available at:**
+- API Gateway: http://localhost:8000
+- Data Service: http://localhost:8001
+- PostgreSQL: localhost:5432
+
+**To stop:**
+```bash
+cd docker
+docker-compose down -v  # -v removes volumes
+```
+
+### Option 2: Manual Setup
+
 ```bash
 # Clone all repos
 git clone https://github.com/Kame4201/beat-books-data.git

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,14 @@
+# Database Configuration
+# Copy this file to .env and fill in your values
+# Never commit the .env file to version control
+
+# PostgreSQL password for production/development
+DB_PASSWORD=your_secure_password_here
+
+# PostgreSQL password for test environment (optional, defaults to 'test_password')
+TEST_DB_PASSWORD=test_password
+
+# Optional: Override default ports if needed
+# POSTGRES_PORT=5432
+# DATA_SERVICE_PORT=8001
+# API_PORT=8000

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,37 @@
+# Development overrides for docker-compose.yml
+# Usage: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+
+services:
+  data-service:
+    build:
+      context: ../beat-books-data
+      dockerfile: Dockerfile
+    volumes:
+      # Mount source code for hot reload
+      - ../beat-books-data/src:/app/src:ro
+    environment:
+      # Development settings
+      DEBUG: "true"
+      LOG_LEVEL: DEBUG
+    command: uvicorn src.main:app --host 0.0.0.0 --port 8001 --reload
+
+  api:
+    build:
+      context: ../beat-books-api
+      dockerfile: Dockerfile
+    volumes:
+      # Mount source code for hot reload
+      - ../beat-books-api/src:/app/src:ro
+    environment:
+      # Development settings
+      DEBUG: "true"
+      LOG_LEVEL: DEBUG
+    command: uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
+
+  postgres:
+    # Expose postgres logs for debugging
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    # Add pgAdmin for database management (optional)
+    ports:
+      - "5432:5432"

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,29 @@
+# Test configuration for docker-compose.yml
+# Usage: docker-compose -f docker-compose.yml -f docker-compose.test.yml up
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: beatthebooks_test
+      POSTGRES_USER: btb_test
+      POSTGRES_PASSWORD: ${TEST_DB_PASSWORD:-test_password}
+    # Use tmpfs for faster tests (no persistence)
+    tmpfs:
+      - /var/lib/postgresql/data
+    ports:
+      - "5433:5432"  # Different port to avoid conflicts
+
+  data-service:
+    environment:
+      DATABASE_URL: postgresql://btb_test:${TEST_DB_PASSWORD:-test_password}@postgres:5432/beatthebooks_test
+      TESTING: "true"
+    command: pytest tests/ -v
+
+  api:
+    environment:
+      DATA_SERVICE_URL: http://data-service:8001
+      TESTING: "true"
+    command: pytest tests/ -v
+
+# No volumes defined - tests should not persist data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: beatthebooks
+      POSTGRES_USER: btb
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  data-service:
+    build: ../beat-books-data
+    ports:
+      - "8001:8001"
+    environment:
+      DATABASE_URL: postgresql://btb:${DB_PASSWORD}@postgres:5432/beatthebooks
+    depends_on:
+      - postgres
+
+  api:
+    build: ../beat-books-api
+    ports:
+      - "8000:8000"
+    environment:
+      DATA_SERVICE_URL: http://data-service:8001
+    depends_on:
+      - data-service
+
+volumes:
+  pgdata:

--- a/scripts/docker-up.ps1
+++ b/scripts/docker-up.ps1
@@ -1,0 +1,39 @@
+# Start the BeatTheBooks stack using Docker Compose
+# Usage: .\scripts\docker-up.ps1 [dev|test|prod]
+
+param(
+    [Parameter(Position=0)]
+    [ValidateSet("dev", "test", "prod")]
+    [string]$Mode = "prod"
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$DockerDir = Join-Path $ProjectRoot "docker"
+
+Set-Location $DockerDir
+
+# Check if .env exists
+if (-not (Test-Path ".env")) {
+    Write-Host "⚠️  No .env file found. Creating from .env.example..." -ForegroundColor Yellow
+    Copy-Item ".env.example" ".env"
+    Write-Host "✏️  Please edit docker\.env with your actual values before proceeding." -ForegroundColor Yellow
+    exit 1
+}
+
+switch ($Mode) {
+    "dev" {
+        Write-Host "🚀 Starting BeatTheBooks stack in DEVELOPMENT mode..." -ForegroundColor Green
+        docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+    }
+    "test" {
+        Write-Host "🧪 Starting BeatTheBooks stack in TEST mode..." -ForegroundColor Cyan
+        docker-compose -f docker-compose.yml -f docker-compose.test.yml up --build --abort-on-container-exit
+    }
+    "prod" {
+        Write-Host "🚀 Starting BeatTheBooks stack in PRODUCTION mode..." -ForegroundColor Green
+        docker-compose up --build
+    }
+}

--- a/scripts/docker-up.sh
+++ b/scripts/docker-up.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Start the BeatTheBooks stack using Docker Compose
+# Usage: ./scripts/docker-up.sh [dev|test|prod]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DOCKER_DIR="$PROJECT_ROOT/docker"
+
+MODE="${1:-prod}"
+
+cd "$DOCKER_DIR"
+
+# Check if .env exists
+if [ ! -f .env ]; then
+    echo "⚠️  No .env file found. Creating from .env.example..."
+    cp .env.example .env
+    echo "✏️  Please edit docker/.env with your actual values before proceeding."
+    exit 1
+fi
+
+case "$MODE" in
+    dev)
+        echo "🚀 Starting BeatTheBooks stack in DEVELOPMENT mode..."
+        docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+        ;;
+    test)
+        echo "🧪 Starting BeatTheBooks stack in TEST mode..."
+        docker-compose -f docker-compose.yml -f docker-compose.test.yml up --build --abort-on-container-exit
+        ;;
+    prod)
+        echo "🚀 Starting BeatTheBooks stack in PRODUCTION mode..."
+        docker-compose up --build
+        ;;
+    *)
+        echo "❌ Invalid mode: $MODE"
+        echo "Usage: $0 [dev|test|prod]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Implements Docker Compose configuration for the full BeatTheBooks stack as requested in issue #3.

## Changes

- Add docker/docker-compose.yml with PostgreSQL, data-service, and API
- Add docker/docker-compose.dev.yml for development with hot reload
- Add docker/docker-compose.test.yml for isolated testing
- Add docker/.env.example with environment variable templates
- Add scripts/docker-up.sh and docker-up.ps1 for easy stack startup
- Update README with Docker quick start instructions

## Testing

To test locally:

```bash
cd docker
cp .env.example .env
# Edit .env and set DB_PASSWORD
cd ..
./scripts/docker-up.sh
```

Services should be available at:
- API: http://localhost:8000
- Data Service: http://localhost:8001
- PostgreSQL: localhost:5432

Resolves #3

---

Generated with [Claude Code](https://claude.ai/code)