### PR TITLE
feat: add GitHub Actions CI pipeline templates

### DIFF
--- a/ci-templates/full-pipeline.yml
+++ b/ci-templates/full-pipeline.yml
@@ -1,0 +1,142 @@
+name: Full CI Pipeline
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+            ${{ runner.os }}-pip-
+
+      - name: Install linting tools
+        run: |
+          pip install ruff black
+
+      - name: Run ruff
+        run: |
+          ruff check src/
+
+      - name: Run black
+        run: |
+          black --check src/
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-mypy-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-mypy-
+            ${{ runner.os }}-pip-
+
+      - name: Install mypy
+        run: |
+          pip install mypy
+
+      - name: Run mypy
+        run: |
+          mypy src/ --ignore-missing-imports
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-test-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src --cov-report=xml --cov-report=term --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-security-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-security-
+            ${{ runner.os }}-pip-
+
+      - name: Install security tools
+        run: |
+          pip install bandit pip-audit
+
+      - name: Run bandit security scan
+        run: |
+          bandit -r src/ -ll
+
+      - name: Run pip-audit for vulnerabilities
+        run: |
+          pip-audit -r requirements.txt

--- a/ci-templates/lint.yml
+++ b/ci-templates/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+            ${{ runner.os }}-pip-
+
+      - name: Install linting tools
+        run: |
+          pip install ruff black
+
+      - name: Run ruff
+        run: |
+          ruff check src/
+
+      - name: Run black
+        run: |
+          black --check src/

--- a/ci-templates/security.yml
+++ b/ci-templates/security.yml
@@ -1,0 +1,43 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Run security scans weekly on Mondays at 9 AM UTC
+    - cron: '0 9 * * 1'
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-security-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-security-
+            ${{ runner.os }}-pip-
+
+      - name: Install security tools
+        run: |
+          pip install bandit pip-audit
+
+      - name: Run bandit security scan
+        run: |
+          bandit -r src/ -ll
+
+      - name: Run pip-audit for vulnerabilities
+        run: |
+          pip-audit -r requirements.txt

--- a/ci-templates/test.yml
+++ b/ci-templates/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-test-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src --cov-report=xml --cov-report=term --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella

--- a/ci-templates/type-check.yml
+++ b/ci-templates/type-check.yml
@@ -1,0 +1,36 @@
+name: Type Check
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-mypy-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-mypy-
+            ${{ runner.os }}-pip-
+
+      - name: Install mypy
+        run: |
+          pip install mypy
+
+      - name: Run mypy
+        run: |
+          mypy src/ --ignore-missing-imports

--- a/docs/sdlc/ci-cd.md
+++ b/docs/sdlc/ci-cd.md
@@ -6,6 +6,64 @@
 Lint (ruff + black) → Type Check (mypy) → Test (pytest + coverage) → Security (bandit + pip-audit)
 ~~~
 
+## Workflow Templates
+
+Reusable GitHub Actions workflow templates are available in the `ci-templates/` directory:
+
+- `lint.yml` - Code linting with ruff and black
+- `test.yml` - Unit tests with pytest and coverage reporting
+- `type-check.yml` - Static type checking with mypy
+- `security.yml` - Security scanning with bandit and pip-audit
+- `full-pipeline.yml` - Combined workflow with proper job dependencies
+
+### How to Use Templates
+
+1. Copy the desired template(s) from `ci-templates/` to your repo's `.github/workflows/` directory
+2. Customize as needed for your specific repo (see per-repo guidance below)
+3. Commit and push to enable CI for your repo
+
+### Per-Repo Customization
+
+#### beat-books-data
+- **Workflows**: Use all templates (lint, test, type-check, security)
+- **Customization**: Default configuration should work
+- **Coverage**: Ensure `--cov-fail-under=70` in test.yml
+
+#### beat-books-model
+- **Workflows**: Use all templates (lint, test, type-check, security)
+- **Customization**:
+  - Add model artifact caching in test.yml:
+    ```yaml
+    - name: Cache trained models
+      uses: actions/cache@v4
+      with:
+        path: models/artifacts/
+        key: ${{ runner.os }}-models-${{ hashFiles('src/features/**') }}
+    ```
+- **Coverage**: Ensure `--cov-fail-under=70` in test.yml
+
+#### beat-books-api
+- **Workflows**: Use all templates (lint, test, type-check, security)
+- **Customization**:
+  - Add Docker build step after tests pass:
+    ```yaml
+    docker-build:
+      needs: [test, security]
+      steps:
+        - name: Build Docker image
+          run: docker build -t beat-books-api:${{ github.sha }} .
+    ```
+- **Coverage**: Adjust to `--cov-fail-under=60` in test.yml
+
+#### beat-books-infra
+- **Workflows**: Use markdownlint only (not Python-based templates)
+- **Customization**:
+  - Create custom workflow for documentation linting:
+    ```yaml
+    - name: Lint markdown
+      run: npx markdownlint-cli docs/
+    ```
+
 ## Coverage Thresholds
 
 | Repo | Minimum Overall | Critical Paths |


### PR DESCRIPTION
Adds reusable GitHub Actions workflow templates for linting, testing, type checking, and security scanning.

## Changes
- Create lint.yml for code linting (ruff + black)
- Create test.yml for unit tests with coverage (pytest)
- Create type-check.yml for static type checking (mypy)
- Create security.yml for security scanning (bandit + pip-audit)
- Create full-pipeline.yml combining all checks with proper dependencies
- Update ci-cd.md with per-repo customization guidance

All templates include pip dependency caching for faster runs.
Full pipeline runs lint → test → security in correct order.

Resolves #2

Generated with [Claude Code](https://claude.ai/code)