### PR TITLE
Restrict Claude to promotion PRs and @claude on stage/main

### DIFF
--- a/ci-templates/claude.yml
+++ b/ci-templates/claude.yml
@@ -9,26 +9,64 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  # NEW: automatically run on promotion PRs (Dev -> stage, stage -> main)
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [stage, main] # base branch only
 
 jobs:
   claude:
+    # 1) Allow @claude on issues anywhere
+    # 2) Allow @claude on PRs ONLY when base branch is stage or main (blocks feature -> Dev)
+    # 3) Auto-run ONLY for Dev -> stage OR stage -> main promotion PRs (release notes / doc prompt)
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        # Auto-run on promotion PRs
+        (github.event_name == 'pull_request' &&
+          (
+            (github.base_ref == 'stage' && github.head_ref == 'Dev') ||
+            (github.base_ref == 'main' && github.head_ref == 'stage')
+          )
+        )
+        ||
+        # On-demand runs when someone tags @claude
+        (
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+          (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        )
+      )
+      &&
+      (
+        # Always allow issues
+        github.event_name == 'issues'
+        ||
+        # For PR-related events, only allow if base is stage or main
+        (
+          github.event_name != 'issues'
+          &&
+          (
+            github.base_ref == 'stage' ||
+            github.base_ref == 'main'
+          )
+        )
+      )
+
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # CHANGED: allow commenting on PRs
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # CHANGED: better context for release notes / diffs
 
       - name: Run Claude Code
         id: claude
@@ -40,11 +78,9 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # If this is a promotion PR, guide Claude to produce release notes / documentation.
+          # Otherwise, Claude will follow the @claude comment instructions.
+          prompt: ${{ (github.event_name == 'pull_request' && ((github.base_ref == 'stage' && github.head_ref == 'Dev') || (github.base_ref == 'main' && github.head_ref == 'stage'))) && format('You are reviewing a promotion pull request ({0} -> {1}).\n\n1) Summarize the changes at a release-notes level.\n2) Call out breaking changes, migrations, config/infra impacts, and risk areas.\n3) Suggest test/verification steps.\n4) Produce a \"Release Notes\" section suitable for copy/paste into the PR description.\nPost your output as a PR comment.', github.head_ref, github.base_ref) || '' }}
 
           # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
Updated Claude configuration to allow automatic runs on promotion PRs and modified permissions for PR comments.