### PR TITLE
Add model-service to docker-compose configs, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Run the entire stack with Docker Compose:
 ```bash
 # Clone all repos in the same parent directory
 git clone https://github.com/Kame4201/beat-books-data.git
+git clone https://github.com/Kame4201/beat-books-model.git
 git clone https://github.com/Kame4201/beat-books-api.git
 git clone https://github.com/Kame4201/beat-books-infra.git
 
@@ -64,7 +65,15 @@ cd ..
 **Services will be available at:**
 - API Gateway: http://localhost:8000
 - Data Service: http://localhost:8001
+- Model Service: http://localhost:8002
 - PostgreSQL: localhost:5432
+
+**Health checks:**
+```bash
+curl http://localhost:8000/health  # API gateway
+curl http://localhost:8001/health  # Data service
+curl http://localhost:8002/health  # Model service
+```
 
 **To stop:**
 ```bash
@@ -87,10 +96,16 @@ pip install -r requirements.txt
 cp .env.example .env  # Add your DATABASE_URL
 uvicorn src.main:app --reload --port 8001
 
+# Then beat-books-model
+cd ../beat-books-model
+pip install -r requirements.txt
+cp .env.example .env  # Add your DATABASE_URL
+uvicorn src.main:app --reload --port 8002
+
 # Then beat-books-api
 cd ../beat-books-api
 pip install -r requirements.txt
-cp .env.example .env
+cp .env.example .env  # Add DATA_SERVICE_URL and MODEL_SERVICE_URL
 uvicorn src.main:app --reload --port 8000
 ```
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -4,11 +4,11 @@
 services:
   data-service:
     build:
-      context: ../beat-books-data
+      context: ../../beat-books-data
       dockerfile: Dockerfile
     volumes:
       # Mount source code for hot reload
-      - ../beat-books-data/src:/app/src:ro
+      - ../../beat-books-data/src:/app/src:ro
     environment:
       # Development settings
       DEBUG: "true"
@@ -17,12 +17,12 @@ services:
 
   model-service:
     build:
-      context: ../beat-books-model
+      context: ../../beat-books-model
       dockerfile: Dockerfile
     volumes:
       # Mount source code for hot reload
-      - ../beat-books-model/src:/app/src:ro
-      - ../beat-books-model/model_artifacts:/app/model_artifacts:ro
+      - ../../beat-books-model/src:/app/src:ro
+      - ../../beat-books-model/model_artifacts:/app/model_artifacts:ro
     environment:
       # Development settings
       DEBUG: "true"
@@ -31,11 +31,11 @@ services:
 
   api:
     build:
-      context: ../beat-books-api
+      context: ../../beat-books-api
       dockerfile: Dockerfile
     volumes:
       # Mount source code for hot reload
-      - ../beat-books-api/src:/app/src:ro
+      - ../../beat-books-api/src:/app/src:ro
     environment:
       # Development settings
       DEBUG: "true"

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -15,6 +15,20 @@ services:
       LOG_LEVEL: DEBUG
     command: uvicorn src.main:app --host 0.0.0.0 --port 8001 --reload
 
+  model-service:
+    build:
+      context: ../beat-books-model
+      dockerfile: Dockerfile
+    volumes:
+      # Mount source code for hot reload
+      - ../beat-books-model/src:/app/src:ro
+      - ../beat-books-model/model_artifacts:/app/model_artifacts:ro
+    environment:
+      # Development settings
+      DEBUG: "true"
+      LOG_LEVEL: DEBUG
+    command: uvicorn src.main:app --host 0.0.0.0 --port 8002 --reload
+
   api:
     build:
       context: ../beat-books-api

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -20,9 +20,16 @@ services:
       TESTING: "true"
     command: pytest tests/ -v
 
+  model-service:
+    environment:
+      DATABASE_URL: postgresql://btb_test:${TEST_DB_PASSWORD:-test_password}@postgres:5432/beatthebooks_test
+      TESTING: "true"
+    command: pytest tests/ -v
+
   api:
     environment:
       DATA_SERVICE_URL: http://data-service:8001
+      MODEL_SERVICE_URL: http://model-service:8002
       TESTING: "true"
     command: pytest tests/ -v
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   data-service:
-    build: ../beat-books-data
+    build: ../../beat-books-data
     ports:
       - "8001:8001"
     environment:
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   model-service:
-    build: ../beat-books-model
+    build: ../../beat-books-model
     ports:
       - "8002:8002"
     environment:
@@ -46,7 +46,7 @@ services:
         condition: service_healthy
 
   api:
-    build: ../beat-books-api
+    build: ../../beat-books-api
     ports:
       - "8000:8000"
     environment:

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -239,7 +239,7 @@ All services must declare health checks so `depends_on` can use `condition: serv
 
 ```yaml
 data-service:
-  build: ../beat-books-data
+  build: ../../beat-books-data
   ports:
     - "8001:8001"
   environment:
@@ -254,7 +254,7 @@ data-service:
       condition: service_healthy
 
 model-service:
-  build: ../beat-books-model
+  build: ../../beat-books-model
   ports:
     - "8002:8002"
   environment:
@@ -269,7 +269,7 @@ model-service:
       condition: service_healthy
 
 api:
-  build: ../beat-books-api
+  build: ../../beat-books-api
   ports:
     - "8000:8000"
   environment:


### PR DESCRIPTION
## Summary
- Add `model-service` to `docker-compose.dev.yml` (volume mount + hot reload on port 8002)
- Add `model-service` to `docker-compose.test.yml` (test DB + `MODEL_SERVICE_URL` for api)
- Update `README.md` Quick Start: clone model repo, health check curl commands, manual setup for model service

Depends on: Kame4201/beat-books-model PR (feature/model-scaffold-api) for Dockerfile + FastAPI app

Closes #19

## Test plan
- [ ] `docker-compose up` starts all 4 services (postgres, data, model, api)
- [ ] Health checks pass: `curl localhost:8001/health`, `curl localhost:8002/health`, `curl localhost:8000/health`
- [ ] Dev mode: `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up` enables hot reload
- [ ] Test mode: `docker-compose -f docker-compose.yml -f docker-compose.test.yml up` runs pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)