### PR TITLE
ci: #25 Convert CI templates to reusable workflows

### DIFF
--- a/ci-templates/README.md
+++ b/ci-templates/README.md
@@ -1,0 +1,80 @@
+# CI Templates
+
+## Reusable Workflows (Recommended)
+
+The reusable workflow files are in `ci-templates/reusable/`. To activate them, the repo owner must copy them into `.github/workflows/` (pushing to `.github/workflows/` requires the `workflow` OAuth scope).
+
+### Deployment step (one-time, requires repo owner)
+
+```bash
+cp ci-templates/reusable/*.yml .github/workflows/
+git add .github/workflows/reusable-*.yml
+git commit -m "ci: add reusable workflows"
+git push
+```
+
+### How to call from an app repo
+
+Create a file like `.github/workflows/ci.yml` in your app repo:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main, Dev]
+  pull_request:
+    branches: [main, Dev]
+
+jobs:
+  ci:
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-full-pipeline.yml@main
+    with:
+      python-version: "3.11"
+      source-dir: "src/"
+      coverage-threshold: 70
+```
+
+Or call individual workflows:
+
+```yaml
+jobs:
+  lint:
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-lint.yml@main
+    with:
+      source-dir: "src/"
+
+  test:
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-test.yml@main
+    with:
+      coverage-threshold: 80
+```
+
+### Available reusable workflows
+
+| Workflow | Inputs | Description |
+|----------|--------|-------------|
+| `reusable-lint.yml` | `python-version`, `source-dir` | Runs ruff + black |
+| `reusable-test.yml` | `python-version`, `source-dir`, `coverage-threshold` | pytest + coverage + Codecov |
+| `reusable-type-check.yml` | `python-version`, `source-dir` | mypy type checking |
+| `reusable-security.yml` | `python-version`, `source-dir` | bandit + pip-audit |
+| `reusable-full-pipeline.yml` | `python-version`, `source-dir`, `coverage-threshold` | All of the above with correct ordering |
+
+### Important notes
+
+- Reference `@main` for latest stable, or pin to a commit SHA for reproducibility.
+- The calling repo must be public, or the infra repo must grant workflow access in Settings > Actions > General > Access.
+
+## Legacy Copy-Paste Templates
+
+The `.yml` files in this directory root are the original copy-paste templates. They still work but require manual syncing across repos. Prefer the reusable workflows above.
+
+| Template | Purpose |
+|----------|---------|
+| `lint.yml` | Ruff + Black |
+| `test.yml` | pytest + coverage |
+| `type-check.yml` | mypy |
+| `security.yml` | bandit + pip-audit |
+| `full-pipeline.yml` | All checks combined |
+| `claude.yml` | Claude Code agent (copy-paste only — repo-specific) |
+| `claude-code-review.yml` | Claude PR review (copy-paste only — repo-specific) |

--- a/ci-templates/reusable/reusable-full-pipeline.yml
+++ b/ci-templates/reusable/reusable-full-pipeline.yml
@@ -1,0 +1,42 @@
+name: Reusable Full CI Pipeline
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        default: "3.11"
+      source-dir:
+        type: string
+        default: "src/"
+      coverage-threshold:
+        type: number
+        default: 70
+
+jobs:
+  lint:
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-lint.yml@main
+    with:
+      python-version: ${{ inputs.python-version }}
+      source-dir: ${{ inputs.source-dir }}
+
+  type-check:
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-type-check.yml@main
+    with:
+      python-version: ${{ inputs.python-version }}
+      source-dir: ${{ inputs.source-dir }}
+
+  test:
+    needs: [lint]
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-test.yml@main
+    with:
+      python-version: ${{ inputs.python-version }}
+      source-dir: ${{ inputs.source-dir }}
+      coverage-threshold: ${{ inputs.coverage-threshold }}
+
+  security:
+    needs: [lint]
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-security.yml@main
+    with:
+      python-version: ${{ inputs.python-version }}
+      source-dir: ${{ inputs.source-dir }}

--- a/ci-templates/reusable/reusable-lint.yml
+++ b/ci-templates/reusable/reusable-lint.yml
@@ -1,0 +1,42 @@
+name: Reusable Lint
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        default: "3.11"
+      source-dir:
+        description: "Directory to lint (e.g. src/)"
+        type: string
+        default: "src/"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+            ${{ runner.os }}-pip-
+
+      - name: Install linting tools
+        run: pip install ruff black
+
+      - name: Run ruff
+        run: ruff check ${{ inputs.source-dir }}
+
+      - name: Run black
+        run: black --check ${{ inputs.source-dir }}

--- a/ci-templates/reusable/reusable-security.yml
+++ b/ci-templates/reusable/reusable-security.yml
@@ -1,0 +1,42 @@
+name: Reusable Security Scan
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        default: "3.11"
+      source-dir:
+        description: "Directory to scan with bandit"
+        type: string
+        default: "src/"
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-security-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-security-
+            ${{ runner.os }}-pip-
+
+      - name: Install security tools
+        run: pip install bandit pip-audit
+
+      - name: Run bandit security scan
+        run: bandit -r ${{ inputs.source-dir }} -ll
+
+      - name: Run pip-audit for vulnerabilities
+        run: pip-audit -r requirements.txt

--- a/ci-templates/reusable/reusable-test.yml
+++ b/ci-templates/reusable/reusable-test.yml
@@ -1,0 +1,52 @@
+name: Reusable Test
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        default: "3.11"
+      coverage-threshold:
+        description: "Minimum coverage percentage"
+        type: number
+        default: 70
+      source-dir:
+        description: "Directory to measure coverage on"
+        type: string
+        default: "src"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-test-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=${{ inputs.source-dir }} --cov-report=xml --cov-report=term --cov-fail-under=${{ inputs.coverage-threshold }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella

--- a/ci-templates/reusable/reusable-type-check.yml
+++ b/ci-templates/reusable/reusable-type-check.yml
@@ -1,0 +1,39 @@
+name: Reusable Type Check
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        default: "3.11"
+      source-dir:
+        description: "Directory to type-check"
+        type: string
+        default: "src/"
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-mypy-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-mypy-
+            ${{ runner.os }}-pip-
+
+      - name: Install mypy
+        run: pip install mypy
+
+      - name: Run mypy
+        run: mypy ${{ inputs.source-dir }} --ignore-missing-imports


### PR DESCRIPTION
Implements #25.

## Changes
- Added `ci-templates/reusable/` with 5 `workflow_call`-based reusable workflows:
  - `reusable-lint.yml` — ruff + black
  - `reusable-test.yml` — pytest + coverage (configurable threshold)
  - `reusable-type-check.yml` — mypy
  - `reusable-security.yml` — bandit + pip-audit
  - `reusable-full-pipeline.yml` — orchestrates all above with correct ordering
- Added `ci-templates/README.md` with migration guide and caller examples

## Note on file location
Files are in `ci-templates/reusable/` rather than `.github/workflows/` because pushing workflows requires the `workflow` OAuth scope. **Owner action needed:** copy files to `.github/workflows/` to activate.

## How to test
1. Validate YAML: `python3 -c "import yaml, pathlib; [yaml.safe_load(p.read_text()) for p in pathlib.Path('ci-templates/reusable').rglob('*.yml')]"`
2. Review `ci-templates/README.md` for migration instructions
3. After copying to `.github/workflows/`, test by calling from an app repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)