### PR TITLE
docs: #43 Developer onboarding guide and bootstrap script

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,132 @@
+# Developer Onboarding Guide
+
+> Get the full BeatTheBooks platform running locally in under 10 minutes.
+
+## Prerequisites
+
+| Tool | Minimum Version | Install |
+|------|----------------|---------|
+| Git | 2.30+ | [git-scm.com](https://git-scm.com/) |
+| Docker | 20.10+ | [docker.com](https://www.docker.com/get-started/) |
+| Docker Compose | v2+ | Included with Docker Desktop |
+| Python | 3.11+ | [python.org](https://www.python.org/downloads/) (for local dev without Docker) |
+| gh CLI | 2.0+ | [cli.github.com](https://cli.github.com/) (optional, recommended) |
+
+## Quick Start (automated)
+
+```bash
+# Clone the infra repo first
+git clone https://github.com/Kame4201/beat-books-infra.git
+cd beat-books-infra
+
+# Run the bootstrap script
+bash scripts/bootstrap.sh
+```
+
+The script will:
+1. Check that prerequisites are installed
+2. Clone all 4 repos as siblings in the same parent directory
+3. Create `.env` files from `.env.example` templates
+4. Start the full stack via Docker Compose (dev mode)
+5. Wait for health checks to pass
+
+Use `--skip-docker` if you only want to clone repos and set up env files.
+
+## Manual Setup
+
+If you prefer to set things up step-by-step:
+
+### 1. Clone all repos
+
+```bash
+mkdir beatthebooks && cd beatthebooks
+git clone https://github.com/Kame4201/beat-books-data.git
+git clone https://github.com/Kame4201/beat-books-model.git
+git clone https://github.com/Kame4201/beat-books-api.git
+git clone https://github.com/Kame4201/beat-books-infra.git
+```
+
+### 2. Configure environment
+
+```bash
+cd beat-books-infra/docker
+cp .env.example .env
+# Edit .env — set DB_PASSWORD at minimum
+```
+
+### 3. Start with Docker Compose
+
+```bash
+# Development mode (hot reload)
+./scripts/docker-up.sh dev
+
+# Production mode
+./scripts/docker-up.sh
+
+# Test mode
+./scripts/docker-up.sh test
+```
+
+### 4. Verify
+
+```bash
+curl http://localhost:8000/health  # API gateway
+curl http://localhost:8001/health  # Data service
+curl http://localhost:8002/health  # Model service
+```
+
+## Repo Overview
+
+```
+beatthebooks/
+├── beat-books-infra/    # You are here — CI, docs, Docker, scripts
+├── beat-books-data/     # Data scraping + storage (port 8001)
+├── beat-books-model/    # ML predictions (port 8002)
+└── beat-books-api/      # API gateway (port 8000)
+```
+
+| Repo | Responsibility | Port | Database Access |
+|------|---------------|------|-----------------|
+| beat-books-data | NFL stat scraping, storage, retrieval | 8001 | Read/Write (schema owner) |
+| beat-books-model | Feature engineering, ML models, bet sizing | 8002 | Read Only |
+| beat-books-api | Public API gateway, routing | 8000 | None (proxies to services) |
+| beat-books-infra | CI templates, Docker configs, docs, scripts | — | None |
+
+## Branching Workflow
+
+All repos use the same branching model:
+
+```
+feature/* → Dev → stage → main
+```
+
+- Create feature branches from `Dev`
+- PRs target `Dev`
+- Promotion PRs: `Dev → stage → main`
+
+See [docs/sdlc/git-workflow.md](sdlc/git-workflow.md) for details.
+
+## Key Documentation
+
+| Doc | Path | Description |
+|-----|------|-------------|
+| Architecture Overview | [docs/architecture/overview.md](architecture/overview.md) | System design and tech stack |
+| Service Contracts | [docs/architecture/service-contracts.md](architecture/service-contracts.md) | HTTP API contracts between services |
+| Database Schema | [docs/architecture/database-schema.md](architecture/database-schema.md) | Table definitions |
+| Testing Standards | [docs/sdlc/testing-standards.md](sdlc/testing-standards.md) | Test patterns and coverage requirements |
+| Secret Management | [docs/operations/secret-management.md](operations/secret-management.md) | How secrets are handled |
+| Roadmap | [docs/roadmap.md](roadmap.md) | Cross-repo issue tracking and phases |
+
+## Troubleshooting
+
+**Docker Compose fails to build:**
+- Ensure all 4 repos are cloned as siblings in the same directory
+- Check that Docker Desktop is running
+
+**Service health check fails:**
+- Check logs: `docker compose -f docker/docker-compose.yml logs <service-name>`
+- Ensure `.env` has valid `DB_PASSWORD`
+
+**Port conflict:**
+- Default ports: 8000, 8001, 8002, 5432
+- Stop any local services on these ports before starting

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# BeatTheBooks — Multi-repo bootstrap script
+# Clones all repos, checks prerequisites, sets up environment, starts the stack.
+# Usage: bash bootstrap.sh [--skip-docker]
+#
+# Assumes you want all repos as siblings in the same parent directory.
+# If run from inside beat-books-infra, it clones siblings next to it.
+set -e
+
+SKIP_DOCKER=false
+if [ "$1" = "--skip-docker" ]; then
+    SKIP_DOCKER=true
+fi
+
+GITHUB_ORG="Kame4201"
+REPOS=("beat-books-data" "beat-books-model" "beat-books-api" "beat-books-infra")
+
+# ---------- helpers ----------
+info()  { echo "  [INFO]  $*"; }
+warn()  { echo "  [WARN]  $*"; }
+fail()  { echo "  [FAIL]  $*" >&2; exit 1; }
+ok()    { echo "  [ OK ]  $*"; }
+
+check_cmd() {
+    if command -v "$1" &>/dev/null; then
+        ok "$1 found: $(command -v "$1")"
+        return 0
+    else
+        warn "$1 not found"
+        return 1
+    fi
+}
+
+# ---------- prerequisite check ----------
+echo ""
+echo "======================================"
+echo "  BeatTheBooks Bootstrap"
+echo "======================================"
+echo ""
+echo "Checking prerequisites..."
+
+MISSING=0
+check_cmd git     || MISSING=1
+check_cmd docker  || MISSING=1
+check_cmd python3 || check_cmd python || MISSING=1
+
+# docker compose (v2 plugin or standalone)
+if docker compose version &>/dev/null 2>&1; then
+    ok "docker compose v2 found"
+elif command -v docker-compose &>/dev/null; then
+    ok "docker-compose (standalone) found"
+else
+    warn "docker compose not found"
+    MISSING=1
+fi
+
+# gh CLI (optional but recommended)
+if check_cmd gh; then
+    info "gh CLI will be used for cloning (faster auth)"
+fi
+
+if [ "$MISSING" -eq 1 ]; then
+    echo ""
+    warn "Some prerequisites are missing. Install them and re-run."
+    warn "Required: git, docker, docker compose, python3"
+    exit 1
+fi
+
+# ---------- determine workspace ----------
+# If we're inside beat-books-infra, go up one level
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/../CLAUDE.md" ] && grep -q "beat-books-infra" "$SCRIPT_DIR/../CLAUDE.md" 2>/dev/null; then
+    WORKSPACE="$(dirname "$SCRIPT_DIR/..")"
+    WORKSPACE="$(cd "$SCRIPT_DIR/.." && cd .. && pwd)"
+    info "Detected beat-books-infra repo; workspace is $WORKSPACE"
+else
+    WORKSPACE="$(pwd)"
+    info "Using current directory as workspace: $WORKSPACE"
+fi
+
+# ---------- clone repos ----------
+echo ""
+echo "Cloning repositories..."
+for REPO in "${REPOS[@]}"; do
+    TARGET="$WORKSPACE/$REPO"
+    if [ -d "$TARGET/.git" ]; then
+        ok "$REPO already cloned at $TARGET"
+        (cd "$TARGET" && git fetch origin --prune -q)
+    else
+        info "Cloning $REPO..."
+        git clone "https://github.com/$GITHUB_ORG/$REPO.git" "$TARGET"
+        ok "$REPO cloned"
+    fi
+done
+
+# ---------- environment setup ----------
+echo ""
+echo "Setting up environment files..."
+INFRA_DIR="$WORKSPACE/beat-books-infra"
+DOCKER_DIR="$INFRA_DIR/docker"
+
+if [ -f "$DOCKER_DIR/.env" ]; then
+    ok "docker/.env already exists"
+else
+    if [ -f "$DOCKER_DIR/.env.example" ]; then
+        cp "$DOCKER_DIR/.env.example" "$DOCKER_DIR/.env"
+        ok "Created docker/.env from .env.example"
+        warn "Edit $DOCKER_DIR/.env and set DB_PASSWORD before starting the stack"
+    else
+        warn "No .env.example found in $DOCKER_DIR"
+    fi
+fi
+
+# Copy .env.example in each app repo if .env doesn't exist
+for REPO in "beat-books-data" "beat-books-model" "beat-books-api"; do
+    REPO_DIR="$WORKSPACE/$REPO"
+    if [ -f "$REPO_DIR/.env.example" ] && [ ! -f "$REPO_DIR/.env" ]; then
+        cp "$REPO_DIR/.env.example" "$REPO_DIR/.env"
+        ok "Created $REPO/.env from .env.example"
+    fi
+done
+
+# ---------- start stack ----------
+if [ "$SKIP_DOCKER" = true ]; then
+    info "Skipping Docker start (--skip-docker flag)"
+else
+    echo ""
+    echo "Starting the stack in development mode..."
+    cd "$DOCKER_DIR"
+    if docker compose version &>/dev/null 2>&1; then
+        docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+    else
+        docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+    fi
+    ok "Stack started in background"
+
+    # ---------- health check ----------
+    echo ""
+    echo "Waiting for services to become healthy (up to 60s)..."
+    SERVICES=("8000" "8001" "8002")
+    NAMES=("API Gateway" "Data Service" "Model Service")
+    for i in 0 1 2; do
+        PORT="${SERVICES[$i]}"
+        NAME="${NAMES[$i]}"
+        HEALTHY=false
+        for ATTEMPT in $(seq 1 12); do
+            if curl -sf "http://localhost:$PORT/health" > /dev/null 2>&1; then
+                ok "$NAME (port $PORT) is healthy"
+                HEALTHY=true
+                break
+            fi
+            sleep 5
+        done
+        if [ "$HEALTHY" = false ]; then
+            warn "$NAME (port $PORT) did not respond within 60s"
+        fi
+    done
+fi
+
+# ---------- done ----------
+echo ""
+echo "======================================"
+echo "  Bootstrap complete!"
+echo "======================================"
+echo ""
+echo "  Repos cloned to: $WORKSPACE"
+echo "  Services:"
+echo "    API Gateway:   http://localhost:8000"
+echo "    Data Service:  http://localhost:8001"
+echo "    Model Service: http://localhost:8002"
+echo "    PostgreSQL:    localhost:5432"
+echo ""
+echo "  Useful commands:"
+echo "    docker compose -f docker/docker-compose.yml logs -f"
+echo "    docker compose -f docker/docker-compose.yml down -v"
+echo ""


### PR DESCRIPTION
Implements #43.

## Changes
- `scripts/bootstrap.sh`: Multi-repo bootstrap script that clones all repos, checks prerequisites (git, docker, python3), copies `.env.example` → `.env`, starts the stack, and validates health checks
- `docs/onboarding.md`: Step-by-step onboarding guide for new contributors with prerequisites, quick start, repo overview, and troubleshooting

## How to test
1. Validate script syntax: `bash -n scripts/bootstrap.sh`
2. Run in a fresh directory: `bash scripts/bootstrap.sh --skip-docker` (clones repos without starting Docker)
3. Review `docs/onboarding.md` for completeness and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)