### PR TITLE
ci: #41 Docker image build, tagging, and registry strategy

### DIFF
--- a/ci-templates/reusable/reusable-docker-build.yml
+++ b/ci-templates/reusable/reusable-docker-build.yml
@@ -1,0 +1,79 @@
+name: Reusable Docker Build & Push
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Image name without registry prefix (e.g. beat-books-data)"
+        type: string
+        required: true
+      context:
+        description: "Docker build context path"
+        type: string
+        default: "."
+      dockerfile:
+        description: "Path to Dockerfile"
+        type: string
+        default: "Dockerfile"
+      push:
+        description: "Push image to registry"
+        type: boolean
+        default: true
+    outputs:
+      image-tag:
+        description: "Full image tag that was built"
+        value: ${{ jobs.build.outputs.image-tag }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        if: ${{ inputs.push }}
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ github.sha }}
+          format: table
+          exit-code: 0
+          severity: CRITICAL,HIGH

--- a/docs/operations/docker-registry.md
+++ b/docs/operations/docker-registry.md
@@ -1,0 +1,108 @@
+# Docker Image Build, Tagging, and Registry Strategy
+
+> Defines how Docker images are built, tagged, stored, and scanned for the BeatTheBooks platform.
+> Related: [Deployment Runbook](deployment-runbook.md) | [Service Contracts](../architecture/service-contracts.md)
+
+## Registry: GitHub Container Registry (GHCR)
+
+We use **GHCR** (`ghcr.io`) because:
+- Free for public repos
+- Integrated with GitHub Actions (no extra credentials)
+- Supports OCI images
+- Per-repo access control via GitHub permissions
+
+### Image naming convention
+
+```
+ghcr.io/kame4201/<service-name>:<tag>
+```
+
+| Service | Image |
+|---------|-------|
+| beat-books-data | `ghcr.io/kame4201/beat-books-data` |
+| beat-books-model | `ghcr.io/kame4201/beat-books-model` |
+| beat-books-api | `ghcr.io/kame4201/beat-books-api` |
+
+## Tagging Strategy
+
+Every image push produces multiple tags:
+
+| Tag | Example | When |
+|-----|---------|------|
+| Short SHA | `abc1234` | Every build |
+| Branch name | `main`, `Dev` | Every build |
+| `latest` | `latest` | Merges to `main` only |
+| SemVer | `1.2.0`, `1.2` | When a `v*` tag is pushed |
+
+### Tag lifecycle
+
+```
+feature branch merge → Dev
+  → ghcr.io/kame4201/beat-books-data:Dev
+  → ghcr.io/kame4201/beat-books-data:<sha>
+
+promotion to main
+  → ghcr.io/kame4201/beat-books-data:main
+  → ghcr.io/kame4201/beat-books-data:latest
+  → ghcr.io/kame4201/beat-books-data:<sha>
+
+release tag (v1.0.0)
+  → ghcr.io/kame4201/beat-books-data:1.0.0
+  → ghcr.io/kame4201/beat-books-data:1.0
+  → ghcr.io/kame4201/beat-books-data:<sha>
+```
+
+## CI Workflow
+
+Use the reusable workflow `ci-templates/reusable/reusable-docker-build.yml`.
+
+### Caller example (in each app repo)
+
+```yaml
+name: Docker Build
+
+on:
+  push:
+    branches: [main, Dev]
+    tags: ["v*"]
+
+jobs:
+  build:
+    uses: Kame4201/beat-books-infra/.github/workflows/reusable-docker-build.yml@main
+    with:
+      image-name: beat-books-data  # change per repo
+    permissions:
+      contents: read
+      packages: write
+```
+
+## Multi-Stage Build Recommendations
+
+Each app repo should use multi-stage Dockerfiles to keep production images slim:
+
+```dockerfile
+# Build stage
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Production stage
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY src/ src/
+EXPOSE 8001
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8001"]
+```
+
+## Security Scanning
+
+The reusable workflow includes **Trivy** vulnerability scanning on every push. It scans for CRITICAL and HIGH severity CVEs. Currently set to non-blocking (`exit-code: 0`) — switch to `exit-code: 1` to enforce.
+
+## Setup Checklist
+
+- [ ] Each app repo has a multi-stage `Dockerfile`
+- [ ] Each app repo calls the reusable docker-build workflow
+- [ ] GHCR packages are linked to the repos (happens automatically on first push)
+- [ ] Reusable workflow is copied to `.github/workflows/` in infra repo (requires `workflow` OAuth scope)


### PR DESCRIPTION
Implements #41.

## Changes
- `ci-templates/reusable/reusable-docker-build.yml`: Reusable workflow for Docker image lifecycle
  - Builds with Docker Buildx + GHA cache
  - Pushes to GHCR (`ghcr.io/kame4201/<service>`)
  - Tags: SHA, branch name, `latest` (on main), semver (on `v*` tags)
  - Trivy vulnerability scanning (CRITICAL/HIGH)
- `docs/operations/docker-registry.md`: Strategy doc covering registry choice, tagging lifecycle, multi-stage build guidance, and setup checklist

## How to test
1. Validate YAML: `python3 -c "import yaml; yaml.safe_load(open('ci-templates/reusable/reusable-docker-build.yml'))"`
2. Review `docs/operations/docker-registry.md` for completeness
3. After activating (copy to `.github/workflows/`), call from an app repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)