### PR TITLE
ci: #42 Cross-service end-to-end smoke test workflow

### DIFF
--- a/ci-templates/smoke-test.yml
+++ b/ci-templates/smoke-test.yml
@@ -1,0 +1,81 @@
+name: Cross-Service Smoke Test
+
+# This workflow starts the full Docker Compose stack and runs smoke tests.
+# It should be triggered manually or on schedule from the infra repo.
+# Requires all 4 repos to be checked out as siblings.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run nightly at 6 AM UTC
+    - cron: '0 6 * * *'
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout infra repo
+        uses: actions/checkout@v4
+        with:
+          repository: Kame4201/beat-books-infra
+          path: beat-books-infra
+
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          repository: Kame4201/beat-books-data
+          path: beat-books-data
+
+      - name: Checkout model repo
+        uses: actions/checkout@v4
+        with:
+          repository: Kame4201/beat-books-model
+          path: beat-books-model
+
+      - name: Checkout api repo
+        uses: actions/checkout@v4
+        with:
+          repository: Kame4201/beat-books-api
+          path: beat-books-api
+
+      - name: Create .env file
+        run: cp beat-books-infra/docker/.env.example beat-books-infra/docker/.env
+
+      - name: Start full stack
+        working-directory: beat-books-infra/docker
+        run: docker compose -f docker-compose.yml up --build -d
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for services..."
+          for i in $(seq 1 24); do
+            ALL_HEALTHY=true
+            for PORT in 8000 8001 8002; do
+              if ! curl -sf "http://localhost:$PORT/health" > /dev/null 2>&1; then
+                ALL_HEALTHY=false
+              fi
+            done
+            if [ "$ALL_HEALTHY" = true ]; then
+              echo "All services healthy after $((i * 5))s"
+              break
+            fi
+            if [ "$i" -eq 24 ]; then
+              echo "Timeout waiting for services"
+              docker compose -f beat-books-infra/docker/docker-compose.yml logs
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Run smoke tests
+        run: bash beat-books-infra/scripts/smoke-test.sh http://localhost
+
+      - name: Collect logs on failure
+        if: failure()
+        working-directory: beat-books-infra/docker
+        run: docker compose -f docker-compose.yml logs --tail=50
+
+      - name: Tear down
+        if: always()
+        working-directory: beat-books-infra/docker
+        run: docker compose -f docker-compose.yml down -v

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# BeatTheBooks — Cross-service smoke test
+# Validates that all services are running and can communicate.
+# Usage: bash scripts/smoke-test.sh [base_url]
+#   base_url defaults to http://localhost
+set -e
+
+BASE="${1:-http://localhost}"
+PASS=0
+FAIL=0
+
+check() {
+    local name="$1"
+    local url="$2"
+    local expected_status="${3:-200}"
+
+    HTTP_CODE=$(curl -s -o /tmp/smoke_body -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+
+    if [ "$HTTP_CODE" = "$expected_status" ]; then
+        echo "  [PASS] $name (HTTP $HTTP_CODE)"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] $name — expected $expected_status, got $HTTP_CODE"
+        if [ -f /tmp/smoke_body ]; then
+            echo "         $(cat /tmp/smoke_body | head -c 200)"
+        fi
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_json_field() {
+    local name="$1"
+    local url="$2"
+    local field="$3"
+    local expected="$4"
+
+    BODY=$(curl -sf "$url" 2>/dev/null || echo "{}")
+    ACTUAL=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('$field',''))" 2>/dev/null || echo "")
+
+    if [ "$ACTUAL" = "$expected" ]; then
+        echo "  [PASS] $name ($field=$ACTUAL)"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] $name — expected $field=$expected, got $field=$ACTUAL"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+echo "======================================"
+echo "  BeatTheBooks Smoke Tests"
+echo "======================================"
+echo ""
+
+# --- Health checks ---
+echo "1. Health Check Endpoints"
+check "API Gateway /health"   "$BASE:8000/health"
+check "Data Service /health"  "$BASE:8001/health"
+check "Model Service /health" "$BASE:8002/health"
+
+echo ""
+echo "2. Health Response Schema"
+check_json_field "API Gateway status field"   "$BASE:8000/health" "status"  "healthy"
+check_json_field "Data Service status field"  "$BASE:8001/health" "status"  "healthy"
+check_json_field "Model Service status field" "$BASE:8002/health" "status"  "healthy"
+
+echo ""
+echo "3. Service Identity"
+check_json_field "Data Service name"  "$BASE:8001/health" "service" "beat-books-data"
+check_json_field "Model Service name" "$BASE:8002/health" "service" "beat-books-model"
+
+echo ""
+echo "4. Error Contract (invalid request should return structured error)"
+check "Data Service 404 on invalid team" "$BASE:8001/teams/nonexistent_team_xyz/stats?season=9999" "404"
+
+echo ""
+echo "======================================"
+echo "  Results: $PASS passed, $FAIL failed"
+echo "======================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Implements #42.

## Changes
- `scripts/smoke-test.sh`: Bash script that tests health endpoints, response schemas (status, service fields), and error contract compliance across all 3 services
- `ci-templates/smoke-test.yml`: GitHub Actions workflow that checks out all 4 repos, starts the Docker Compose stack, waits for health, runs smoke tests, and collects logs on failure. Runs nightly + manual dispatch.

## How to test
1. `bash -n scripts/smoke-test.sh` (syntax check)
2. Start the stack locally, then: `bash scripts/smoke-test.sh`
3. Validate workflow YAML: `python3 -c "import yaml; yaml.safe_load(open('ci-templates/smoke-test.yml'))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)