### PR TITLE
chore: #45 Dependabot configuration template

### DIFF
--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for BeatTheBooks app repos
+# Copy this file to .github/dependabot.yml in each app repo.
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # Python dependencies (requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps):"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci):"
+
+  # Docker (if Dockerfile exists)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker):"


### PR DESCRIPTION
Implements #45.

## Changes
- `templates/.github/dependabot.yml`: Dependabot config template covering:
  - **pip** — weekly on Mondays, limit 5 PRs
  - **github-actions** — weekly on Mondays, limit 3 PRs
  - **docker** — monthly
  - Conventional commit prefixes (`chore(deps):`, `chore(ci):`, `chore(docker):`)
  - Auto-labels for `dependencies`, `ci`, `docker`

## How to test
1. Validate YAML: `python3 -c "import yaml; yaml.safe_load(open('templates/.github/dependabot.yml'))"`
2. Copy to `.github/dependabot.yml` in each app repo to activate
3. Dependabot will start opening PRs on the next Monday after activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)