### PR TITLE
chore: #46 Pre-commit hook configuration template

### DIFF
--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# Pre-commit hooks for BeatTheBooks app repos
+# Copy this file to the root of each app repo.
+#
+# Setup:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Run on all files (optional):
+#   pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+        additional_dependencies: []
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.2
+    hooks:
+      - id: bandit
+        args: [-r, src/, -ll]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict


### PR DESCRIPTION
Implements #46.

## Changes
- `templates/.pre-commit-config.yaml`: Pre-commit config template with:
  - **ruff** — linting with auto-fix + formatting (replaces black)
  - **mypy** — type checking
  - **bandit** — security scanning
  - **pre-commit-hooks** — trailing whitespace, end-of-file fixer, YAML check, large file check, merge conflict detection

## How to test
1. Validate YAML: `python3 -c "import yaml; yaml.safe_load(open('templates/.pre-commit-config.yaml'))"`
2. Copy to app repo root as `.pre-commit-config.yaml`
3. `pip install pre-commit && pre-commit install && pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)