### PR TITLE
docs: #40 Shared types proposal and contract stub templates

### DIFF
--- a/docs/architecture/shared-types-proposal.md
+++ b/docs/architecture/shared-types-proposal.md
@@ -1,0 +1,82 @@
+# Shared Types: Cross-Repo Contract Enforcement Proposal
+
+> Proposes how to enforce service contracts in code without putting application code in beat-books-infra.
+> Related: [Service Contracts](service-contracts.md) | CLAUDE.md ("NEVER put application code here")
+
+## Problem
+
+Service contracts are defined in `docs/architecture/service-contracts.md` but enforced only by per-repo JSON schema tests (Option C). Each repo independently defines its own Pydantic models for health checks, error responses, and DTOs. When `beat-books-data` changes a response field, `beat-books-api` breaks at runtime with no warning.
+
+## Constraint
+
+`CLAUDE.md` states: **"NEVER put application code here (no Python services, models, etc.)"**. Therefore, we cannot host an installable Python package in this repo.
+
+## Recommended Solution: Contract Stub Templates
+
+### What goes in beat-books-infra
+
+Pydantic model stubs in `templates/contract_stubs/` that app repos **copy** into their codebase. These are templates, not an installable package.
+
+### What goes in app repos
+
+Each app repo vendors (copies) the stubs and imports them. When contracts change, update the stubs in infra first, then copy to app repos.
+
+## Contract Stubs
+
+The following stubs are provided in `templates/contract_stubs/` and align exactly with `docs/architecture/service-contracts.md`:
+
+### `contracts.py`
+
+Defines the shared Pydantic models:
+- `HealthResponse` — standard health check response
+- `ErrorResponse` — standard error response
+- `PaginatedResponse` — standard pagination wrapper
+
+### Usage in app repos
+
+```python
+# Copy templates/contract_stubs/contracts.py to your repo, e.g.:
+#   cp beat-books-infra/templates/contract_stubs/contracts.py src/contracts.py
+
+from src.contracts import HealthResponse, ErrorResponse
+
+@app.get("/health")
+def health() -> HealthResponse:
+    return HealthResponse(
+        status="healthy",
+        service="beat-books-data",
+        version="0.1.0"
+    )
+```
+
+## Future: Standalone Package (beat-books-shared)
+
+If the platform grows beyond 3 services or contract drift becomes a real problem, consider creating a `beat-books-shared` repo with:
+
+```
+beat-books-shared/
+├── pyproject.toml
+├── src/
+│   └── beat_books_shared/
+│       ├── __init__.py
+│       ├── health.py
+│       ├── errors.py
+│       └── pagination.py
+└── tests/
+```
+
+App repos would then `pip install` it:
+```
+# requirements.txt
+beat-books-shared @ git+https://github.com/Kame4201/beat-books-shared.git@v0.1.0
+```
+
+**Not recommended yet** — adds dependency management complexity for 3 services. The copy-paste stubs approach is sufficient for current scale.
+
+## Decision Log
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| **A: Contract stubs in infra/templates** | No app code in infra, simple copy | Manual sync | **Current choice** |
+| B: beat-books-shared repo | Single source of truth, pip install | Extra repo, versioning overhead | Future option |
+| C: Status quo (JSON tests only) | Zero effort | Contracts drift, runtime breakage | Not recommended |

--- a/templates/contract_stubs/README.md
+++ b/templates/contract_stubs/README.md
@@ -1,0 +1,34 @@
+# Contract Stubs
+
+Pydantic model stubs that enforce the schemas defined in `docs/architecture/service-contracts.md`.
+
+## How to use
+
+Copy `contracts.py` into your app repo:
+
+```bash
+cp beat-books-infra/templates/contract_stubs/contracts.py src/contracts.py
+```
+
+Then import and use:
+
+```python
+from src.contracts import HealthResponse, ErrorResponse
+
+@app.get("/health")
+def health() -> HealthResponse:
+    return HealthResponse(status="healthy", service="beat-books-data", version="0.1.0")
+```
+
+## When to update
+
+When `docs/architecture/service-contracts.md` changes, update `contracts.py` here first, then copy to all app repos.
+
+## Models provided
+
+| Model | Contract Section | Purpose |
+|-------|-----------------|---------|
+| `HealthResponse` | Standard Health Check | `GET /health` response |
+| `ErrorResponse` | Standard Error Response | All error responses |
+| `PaginationMeta` | Pagination | Pagination metadata |
+| `PaginatedResponse` | Pagination | Paginated list wrapper |

--- a/templates/contract_stubs/contracts.py
+++ b/templates/contract_stubs/contracts.py
@@ -1,0 +1,56 @@
+"""
+BeatTheBooks — Shared Contract Stubs
+
+Copy this file into each app repo to enforce consistent response schemas.
+These models align with docs/architecture/service-contracts.md.
+
+Usage:
+    cp beat-books-infra/templates/contract_stubs/contracts.py src/contracts.py
+
+Source of truth: beat-books-infra/docs/architecture/service-contracts.md
+"""
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+
+
+# --- Standard Health Check (service-contracts.md §1) ---
+
+
+class HealthResponse(BaseModel):
+    """Standard health check response. All services must return this from GET /health."""
+
+    status: str  # Always "healthy" if responding
+    service: str  # e.g. "beat-books-data", "beat-books-model", "beat-books-api"
+    version: str  # SemVer from pyproject.toml
+
+
+# --- Standard Error Response (service-contracts.md §2) ---
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response. All services must return errors in this format."""
+
+    error: str  # Machine-readable error code (UPPER_SNAKE_CASE)
+    detail: str  # Human-readable explanation
+    status_code: int  # HTTP status code (mirrored in body)
+
+
+# --- Pagination (service-contracts.md — used by /games, /standings) ---
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata included in paginated responses."""
+
+    page: int
+    limit: int
+    total: int
+    total_pages: int
+
+
+class PaginatedResponse(BaseModel):
+    """Wrapper for paginated list responses."""
+
+    data: List[Any]
+    pagination: PaginationMeta


### PR DESCRIPTION
Implements #40.

## CLAUDE.md Compliance
Issue #40 originally requested an installable Python types package, but CLAUDE.md states: "NEVER put application code here." This PR takes the safe approach:

1. **Proposal doc** (`docs/architecture/shared-types-proposal.md`) — evaluates options (stubs vs shared repo vs status quo) and recommends contract stubs for current scale
2. **Contract stub templates** (`templates/contract_stubs/contracts.py`) — Pydantic models that app repos copy/vendor, NOT an installable package

## Changes
- `docs/architecture/shared-types-proposal.md`: Decision doc with options table
- `templates/contract_stubs/contracts.py`: Pydantic stubs (HealthResponse, ErrorResponse, PaginationMeta, PaginatedResponse) aligned to `service-contracts.md`
- `templates/contract_stubs/README.md`: Usage instructions

## How to test
1. Validate Python: `python3 -c "import ast; ast.parse(open('templates/contract_stubs/contracts.py').read())"`
2. Verify models match `docs/architecture/service-contracts.md`
3. Copy `contracts.py` to an app repo and run `python3 -c "from contracts import HealthResponse; print(HealthResponse(status='healthy', service='test', version='0.1.0'))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)