### PR TITLE
ci: Markdown lint CI pipeline (#14)

### DIFF
--- a/ci-templates/markdown-lint.yml
+++ b/ci-templates/markdown-lint.yml
@@ -1,0 +1,15 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint markdown
+        run: npx markdownlint-cli docs/


### PR DESCRIPTION
Closes #14

## What changed
- Added `ci-templates/markdown-lint.yml`: GitHub Actions workflow that runs `markdownlint-cli` against `docs/` on push to main and PRs targeting main.

**Note:** File is in `ci-templates/` because pushing to `.github/workflows/` requires the `workflow` OAuth scope. Owner should copy:
```bash
cp ci-templates/markdown-lint.yml .github/workflows/markdown-lint.yml
```

## How to test
1. Validate YAML: `python3 -c "import yaml; yaml.safe_load(open('ci-templates/markdown-lint.yml'))"`
2. After copying to `.github/workflows/`, the `markdown-lint` check will appear on PRs
3. Test locally: `npx markdownlint-cli docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)