### PR TITLE
chore: Configure branch protection rules for main (#15)

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Configure branch protection rules for the main branch.
+# Requires: gh CLI authenticated with admin access.
+# Usage: bash scripts/setup-branch-protection.sh [REPO]
+set -e
+
+REPO="${1:-Kame4201/beat-books-infra}"
+
+echo "Setting branch protection on $REPO main branch..."
+
+gh api "repos/$REPO/branches/main/protection" \
+  -X PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["markdown-lint"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1
+  },
+  "restrictions": null
+}
+EOF
+
+echo "Branch protection configured:"
+echo "  - 1 PR review required"
+echo "  - markdown-lint status check required"
+echo "  - Branches must be up to date with main"


### PR DESCRIPTION
Closes #15

## What changed
- **Branch protection applied** via GitHub API (already active on `main`):
  - Require 1 PR review before merging
  - Require `markdown-lint` status check to pass
  - Require branches to be up to date with `main`
- `scripts/setup-branch-protection.sh`: Reproducible script for re-applying the rules

## How to test
1. Verify protection is active: `gh api repos/Kame4201/beat-books-infra/branches/main/protection --jq '.required_pull_request_reviews.required_approving_review_count'` → should return `1`
2. Verify status check: `gh api repos/Kame4201/beat-books-infra/branches/main/protection/required_status_checks --jq '.contexts'` → should include `markdown-lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)